### PR TITLE
Command for dump entity translations

### DIFF
--- a/Command/Entity/DumpEntityTranslationsCommand.php
+++ b/Command/Entity/DumpEntityTranslationsCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Gorgo\Bundle\PlatformDebugBundle\Command\Entity;
+
+use Oro\Bundle\TranslationBundle\Translation\Translator;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Translation\Util\ArrayConverter;
+use Symfony\Component\Yaml\Yaml;
+
+class DumpEntityTranslationsCommand extends ContainerAwareCommand
+{
+    const NAME = 'gorgo:entity:translations:dump';
+    const INLINE_LEVEL = 10;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName(self::NAME)
+            ->setDescription('Dump translations for entity')
+            ->addArgument(
+                'entity',
+                InputArgument::REQUIRED,
+                'Entity class name whose translations should to be dumped, like "Oro/Bundle/TaskBundle/Entity/Task"'
+            )
+            ->addOption(
+                'locale',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Locale whose translations should to be dumped',
+                Translator::DEFAULT_LOCALE
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $entityClass = $input->getArgument('entity');
+        $fieldsProvider = $this->getContainer()->get('oro_entity.entity_field_provider');
+        $entity = $this->getContainer()->get('oro_entity.entity_provider')->getEntity($entityClass, false);
+        $translationKeys = [$entity['label'], $entity['plural_label']];
+
+        $translationKeys = array_merge(
+            $translationKeys,
+            array_map(
+                function ($field) {
+                    return $field['label'];
+                },
+                $fieldsProvider->getFields($entityClass, false, false, false, false, true, false)
+            )
+        );
+
+        $translations = $this->processKeys(
+            $this->getContainer()->get('translator.default'),
+            $translationKeys,
+            $input->getOption('locale')
+        );
+
+        $output->write(Yaml::dump(ArrayConverter::expandToTree($translations), self::INLINE_LEVEL));
+    }
+
+    /**
+     * @param Translator $translator
+     * @param array $keys
+     * @param string|null $locale
+     *
+     * @return array
+     */
+    protected function processKeys(Translator $translator, array $keys, $locale)
+    {
+        $translations = [];
+        foreach ($keys as $key) {
+            if ($translator->hasTrans($key, null, $locale)) {
+                $translation = $translator->trans($key, [], null, $locale);
+            } elseif ($translator->hasTrans($key, null, Translator::DEFAULT_LOCALE)) {
+                $translation = $translator->trans($key, [], null, Translator::DEFAULT_LOCALE);
+            } else {
+                $translation = '';
+            }
+
+            $translations[$key] = $translation;
+        }
+
+        return $translations;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Gorgo Platform Debug Bundle
+
+Table of Commands
+-----------------
+ - [Entity Translations Dump](./Resources/doc/Command/entity.translations.dump.md)

--- a/Resources/doc/Command/entity.translations.dump.md
+++ b/Resources/doc/Command/entity.translations.dump.md
@@ -1,0 +1,64 @@
+Usage: 
+```bash
+$ app gorgo:entity:translations:dump "Oro\Bundle\ContactBundle\Entity\Contact"
+or
+$ app gorgo:entity:translations:dump "OroContactBundle:Contact"
+```
+
+Sample output:
+```
+oro:
+    contact:
+        entity_label: Contact
+        entity_plural_label: Contacts
+        birthday:
+            label: Birthday
+        description:
+            label: Description
+        facebook:
+            label: Facebook
+        fax:
+            label: Fax
+        first_name:
+            label: 'First name'
+        gender:
+            label: Gender
+        google_plus:
+            label: Google+
+        id:
+            label: Id
+        identification_number:
+            label: 'Identification number'
+        job_title:
+            label: 'Job Title'
+        last_name:
+            label: 'Last name'
+        linked_in:
+            label: LinkedIn
+        middle_name:
+            label: 'Middle name'
+        name_prefix:
+            label: 'Name prefix'
+        name_suffix:
+            label: 'Name suffix'
+        skype:
+            label: Skype
+        twitter:
+            label: Twitter
+    activity_contact:
+        ac_contact_count:
+            label: 'Total times contacted'
+        ac_contact_count_in:
+            label: 'Total number of incoming contact attempts'
+        ac_contact_count_out:
+            label: 'Total number of outgoing contact attempts'
+        ac_last_contact_date:
+            label: 'Last contact datetime'
+        ac_last_contact_date_in:
+            label: 'Last incoming contact datetime'
+        ac_last_contact_date_out:
+            label: 'Last outgoing contact datetime'
+    ui:
+        created_at: 'Created At'
+        updated_at: 'Updated At'
+```


### PR DESCRIPTION
Example usage: 
```bash
$ app gorgo:entity:translations:dump "Oro\Bundle\ContactBundle\Entity\Contact"
```
output:
```
oro:
    contact:
        entity_label: Contact
        entity_plural_label: Contacts
        birthday:
            label: Birthday
        description:
            label: Description
        facebook:
            label: Facebook
        fax:
            label: Fax
        first_name:
            label: 'First name'
        gender:
            label: Gender
        google_plus:
            label: Google+
        id:
            label: Id
        identification_number:
            label: 'Identification number'
        job_title:
            label: 'Job Title'
        last_name:
            label: 'Last name'
        linked_in:
            label: LinkedIn
        middle_name:
            label: 'Middle name'
        name_prefix:
            label: 'Name prefix'
        name_suffix:
            label: 'Name suffix'
        skype:
            label: Skype
        twitter:
            label: Twitter
    activity_contact:
        ac_contact_count:
            label: 'Total times contacted'
        ac_contact_count_in:
            label: 'Total number of incoming contact attempts'
        ac_contact_count_out:
            label: 'Total number of outgoing contact attempts'
        ac_last_contact_date:
            label: 'Last contact datetime'
        ac_last_contact_date_in:
            label: 'Last incoming contact datetime'
        ac_last_contact_date_out:
            label: 'Last outgoing contact datetime'
    ui:
        created_at: 'Created At'
        updated_at: 'Updated At'

```