### PR TITLE
Increase verbosity level for MQ

### DIFF
--- a/DependencyInjection/CompilerPass/MessageQueueDebugPass.php
+++ b/DependencyInjection/CompilerPass/MessageQueueDebugPass.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Gorgo\Bundle\PlatformDebugBundle\DependencyInjection\CompilerPass;
+
+use Gorgo\Bundle\PlatformDebugBundle\MessageQueue\Command\ConsumeCommand;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class MessageQueueDebugPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->replaceClass($container);
+        $this->loggerCollect($container);
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    protected function replaceClass(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('oro_message_queue.client.consume_messages_command')) {
+            $definition = $container->getDefinition('oro_message_queue.client.consume_messages_command');
+            $definition->setClass(ConsumeCommand::class);
+            $definition->addMethodCall('setExtension', [new Reference('gorgo.message_queue.extension.debug_extension')]);
+        }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    protected function loggerCollect(ContainerBuilder $container)
+    {
+        $channels = ['app'];
+        if ($container->hasDefinition('gorgo.message_queue.extension.debug_extension')) {
+            $extension = $container->getDefinition('gorgo.message_queue.extension.debug_extension');
+
+            foreach ($container->findTaggedServiceIds('monolog.logger') as $id => $tags) {
+                foreach ($tags as $tag) {
+                    if (empty($tag['channel'])) {
+                        continue;
+                    }
+
+                    $resolvedChannel = $container->getParameterBag()->resolveValue($tag['channel']);
+                    $channels[] = sprintf('monolog.logger.%s', $resolvedChannel);
+                }
+            }
+
+            foreach (array_unique($channels) as $chanel) {
+                if ($container->hasDefinition($chanel)) {
+                    $extension->addMethodCall('addLogger', [new Reference($chanel)]);
+                }
+            }
+        }
+    }
+}

--- a/GorgoPlatformDebugBundle.php
+++ b/GorgoPlatformDebugBundle.php
@@ -2,8 +2,17 @@
 
 namespace Gorgo\Bundle\PlatformDebugBundle;
 
+use Gorgo\Bundle\PlatformDebugBundle\DependencyInjection\CompilerPass\MessageQueueDebugPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class GorgoPlatformDebugBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new MessageQueueDebugPass());
+    }
 }

--- a/MessageQueue/Command/ConsumeCommand.php
+++ b/MessageQueue/Command/ConsumeCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Gorgo\Bundle\PlatformDebugBundle\MessageQueue\Command;
+
+use Gorgo\Bundle\PlatformDebugBundle\MessageQueue\Extension\DebugExtension;
+use Oro\Component\MessageQueue\Client\ConsumeMessagesCommand;
+use Oro\Component\MessageQueue\Consumption\ExtensionInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConsumeCommand extends ConsumeMessagesCommand
+{
+    /** @var ExtensionInterface|DebugExtension */
+    protected $debugExtension;
+
+    /**
+     * @param ExtensionInterface $extension
+     */
+    public function setExtension(ExtensionInterface $extension)
+    {
+        $this->debugExtension = $extension;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+        $this->addOption('debug', null, InputOption::VALUE_NONE, 'Show all logs in console')
+            ->addOption('debug-excluded', null, InputOption::VALUE_OPTIONAL, 'Set excluded loggers chain, separated by common');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getLimitsExtensions(InputInterface $input, OutputInterface $output)
+    {
+        $extensions = parent::getLimitsExtensions($input, $output);
+
+        if ($input->getOption('debug')) {
+            if ($input->getOption('debug-excluded')) {
+                $loggerChains = explode(',', $input->getOption('debug-excluded'));
+                $this->debugExtension->setExcludedLoggerChain($loggerChains);
+            }
+            $extensions[] = $this->debugExtension;
+        }
+
+        return $extensions;
+    }
+}

--- a/MessageQueue/Extension/DebugExtension.php
+++ b/MessageQueue/Extension/DebugExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Gorgo\Bundle\PlatformDebugBundle\MessageQueue\Extension;
+
+use Gorgo\Bundle\PlatformDebugBundle\MessageQueue\Log\ProxyHandler;
+use Monolog\Logger;
+use Oro\Component\MessageQueue\Consumption\AbstractExtension;
+use Oro\Component\MessageQueue\Consumption\Context;
+use Psr\Log\LoggerInterface;
+
+class DebugExtension extends AbstractExtension
+{
+    /** @var LoggerInterface|Logger */
+    protected $loggers = [];
+
+    /** @var array */
+    protected $excludedLoggerChains = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addLogger(LoggerInterface $logger)
+    {
+        $this->loggers[] = $logger;
+    }
+
+    /**
+     * @param array $loggerChain
+     */
+    public function setExcludedLoggerChain(array $loggerChain)
+    {
+        $this->excludedLoggerChains = $loggerChain;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onStart(Context $context)
+    {
+        $debugHandler = new ProxyHandler();
+        $debugHandler->setLogger($context->getLogger());
+        foreach ($this->loggers as $logger) {
+            if (!$logger instanceof Logger || in_array($logger->getName(), $this->excludedLoggerChains)) {
+                continue;
+            }
+
+            $logger->setHandlers(
+                array_merge([$debugHandler], $logger->getHandlers())
+            );
+        }
+    }
+}

--- a/MessageQueue/Log/ProxyHandler.php
+++ b/MessageQueue/Log/ProxyHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gorgo\Bundle\PlatformDebugBundle\MessageQueue\Log;
+
+use Monolog\Handler\AbstractProcessingHandler;
+use Psr\Log\LoggerInterface;
+
+class ProxyHandler extends AbstractProcessingHandler
+{
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record)
+    {
+        $this->logger->log(
+            strtolower($record['level_name']),
+            $record['formatted'],
+            $record['context']
+        );
+    }
+}

--- a/Resources/config/client.yml
+++ b/Resources/config/client.yml
@@ -1,0 +1,3 @@
+services:
+    gorgo.message_queue.extension.debug_extension:
+        class: Gorgo\Bundle\PlatformDebugBundle\MessageQueue\Extension\DebugExtension

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,5 +3,6 @@ imports:
     - { resource: 'action_services.yml', ignore_errors: true }
     - { resource: 'database_services.yml', ignore_errors: true }
     - { resource: 'message_queue.yml', ignore_errors: true }
+    - { resource: 'client.yml', ignore_errors: true }
 
 services:


### PR DESCRIPTION
- added optional debug option for command oro:message-queue:consume to display all logs in console
### Example usage
```
$ app oro:message-queue:consume -vvv --debug
```
Output
```
[debug] Set context's logger Symfony\Component\Console\Logger\ConsoleLogger
[info] Start consuming
[debug] Switch to a queue oro.default
[debug] [CreateQueueExtension] Make sure the queue oro.default exists on a broker side.
[debug] [2017-06-25 21:02:04] doctrine.DEBUG: UPDATE oro_message_queue SET consumer_id=NULL, redelivered=:isRedelivered WHERE consumer_id IN (:consumerIds) {"isRedelivered":true,"consumerIds":["59501605141348.77257742","5950166cd28124.54881838"]} []

[alert] [RedeliverOrphanMessagesDbalExtension] Orphans were found and redelivered. consumerIds: "59501605141348.77257742, 5950166cd28124.54881838"
[info] Pre receive Message
[debug] [2017-06-25 21:02:04] doctrine.DEBUG: "START TRANSACTION" [] []

[debug] [2017-06-25 21:02:04] doctrine.DEBUG: SELECT id FROM oro_message_queue WHERE queue=:queue AND consumer_id IS NULL AND (delayed_until IS NULL OR delayed_until<=:delayedUntil) ORDER BY priority DESC, id ASC LIMIT 1 FOR UPDATE {"queue":"oro.default","delayedUntil":1498420924} []

[debug] [2017-06-25 21:02:04] doctrine.DEBUG: UPDATE oro_message_queue SET consumer_id=:consumerId  WHERE id = :messageId {"messageId":248,"consumerId":"595016bceae075.95288149"} []

[debug] [2017-06-25 21:02:04] doctrine.DEBUG: SELECT * FROM oro_message_queue WHERE consumer_id=:consumerId AND queue=:queue LIMIT 1 {"consumerId":"595016bceae075.95288149","queue":"oro.default"} []

[debug] [2017-06-25 21:02:04] doctrine.DEBUG: "COMMIT" [] []

[info] Message received
```
### Excluded logger channel
You can use command options `--debug-excluded=channel1,channel2` to filter by logger channel, for example you will see all the logs except doctrine
```
$ app oro:message-queue:consume -vvv --debug --debug-excluded=doctrine
```